### PR TITLE
feat: handlers can now define sync/async functions

### DIFF
--- a/packages/hisma/lib/src/action.dart
+++ b/packages/hisma/lib/src/action.dart
@@ -1,7 +1,9 @@
+import 'dart:async';
+
 import 'state_machine.dart';
 
 // TODO: shall we clone a Function??
-typedef ActionFunction = Future<void> Function(
+typedef ActionFunction = FutureOr<void> Function(
   StateMachine<dynamic, dynamic, dynamic> machine,
   dynamic arg,
 );

--- a/packages/hisma/lib/src/guard.dart
+++ b/packages/hisma/lib/src/guard.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
+
 import '../hisma.dart';
 
-typedef GuardFunction = Future<bool> Function(
+typedef GuardFunction = FutureOr<bool> Function(
   StateMachine<dynamic, dynamic, dynamic> machine,
   dynamic arg,
 );

--- a/packages/hisma/lib/src/transition.dart
+++ b/packages/hisma/lib/src/transition.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'action.dart';
 import 'guard.dart';
 import 'state_machine.dart';
@@ -91,7 +93,7 @@ class OnErrorData {
   dynamic arg;
 }
 
-typedef OnErrorActionFunction = Future<void> Function(
+typedef OnErrorActionFunction = FutureOr<void> Function(
   StateMachine<dynamic, dynamic, dynamic> machine,
   OnErrorData data,
 );
@@ -101,7 +103,7 @@ class OnErrorAction {
 
   factory OnErrorAction.noAction() => OnErrorAction(
         description: 'nope',
-        action: (_, __) async {},
+        action: (_, __) {},
       );
 
   String description;

--- a/packages/hisma/test/compound_action_test.dart
+++ b/packages/hisma/test/compound_action_test.dart
@@ -34,7 +34,7 @@ StateMachine<S, E, T> createMachine({
           },
           onEntry: Action(
             description: 'add',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               print(
                 '${machine.name}/${machine.activeStateId} - onEntry - data: ${machine.data}, arg: $arg',
               );
@@ -45,7 +45,7 @@ StateMachine<S, E, T> createMachine({
           ),
           onExit: Action(
             description: 'subtract',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               print(
                 '${machine.name}/${machine.activeStateId} - onExit - data: ${machine.data}, arg: $arg',
               );
@@ -97,7 +97,7 @@ StateMachine<S, E, T> createMachine({
                 ],
           onEntry: Action(
             description: 'add',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               print(
                 '${machine.name}/${machine.activeStateId} - onEntry - data: ${machine.data}, arg: $arg',
               );
@@ -108,7 +108,7 @@ StateMachine<S, E, T> createMachine({
           ),
           onExit: Action(
             description: 'subtract',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               print(
                 '${machine.name}/${machine.activeStateId} - data: ${machine.data}, arg: $arg',
               );
@@ -133,7 +133,7 @@ StateMachine<S, E, T> createMachine({
           to: S.b,
           onAction: Action(
             description: 'add',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               print(
                 '${machine.name}/${machine.activeStateId} - toB Transition action @ ${machine.name}, data: ${machine.data}, arg:$arg',
               );

--- a/packages/hisma/test/guard_test.dart
+++ b/packages/hisma/test/guard_test.dart
@@ -34,7 +34,7 @@ StateMachine<S, E, T> createMachine() => StateMachine<S, E, T>(
           to: S.b,
           guard: Guard(
             description: 'only if data > 10',
-            condition: (machine, data) async {
+            condition: (machine, data) {
               return data is int && data > 10;
             },
           ),
@@ -52,13 +52,14 @@ StateMachine<S, E, T> createMachine() => StateMachine<S, E, T>(
           to: S.b,
           guard: Guard(
             description: 'only if data > 10',
-            condition: (machine, data) async {
+            condition: (machine, data) {
               return data is int && data > 10;
             },
           ),
           onError: OnErrorAction(
             description: 'Set data to true.',
             action: (machine, data) async {
+              await Future<void>.delayed(Duration.zero);
               expect(data.source, OnErrorSource.guard);
               machine.data = true;
             },
@@ -74,7 +75,7 @@ StateMachine<S, E, T> createMachine() => StateMachine<S, E, T>(
           ),
           onError: OnErrorAction(
             description: 'Set data to true.',
-            action: (machine, data) async {
+            action: (machine, data) {
               expect(data.source, OnErrorSource.guard);
               machine.data = true;
             },

--- a/packages/hisma/test/multiple_transitions_and_priorities_test.dart
+++ b/packages/hisma/test/multiple_transitions_and_priorities_test.dart
@@ -46,7 +46,7 @@ StateMachine<S, E, T> createSimpleMachine(String name) => StateMachine<S, E, T>(
           priority: 10,
           guard: Guard(
             description: cb,
-            condition: (machine, arg) async {
+            condition: (machine, arg) {
               return arg is! Map<String, bool> || (arg[cb] ?? false);
             },
           ),
@@ -57,7 +57,7 @@ StateMachine<S, E, T> createSimpleMachine(String name) => StateMachine<S, E, T>(
           priority: 30,
           guard: Guard(
             description: cc,
-            condition: (machine, arg) async {
+            condition: (machine, arg) {
               return arg is! Map<String, bool> || (arg[cc] ?? false);
             },
           ),
@@ -68,7 +68,7 @@ StateMachine<S, E, T> createSimpleMachine(String name) => StateMachine<S, E, T>(
           priority: 20,
           guard: Guard(
             description: cd,
-            condition: (machine, arg) async {
+            condition: (machine, arg) {
               return arg is! Map<String, bool> || (arg[cd] ?? false);
             },
           ),

--- a/packages/hisma/test/state_action_test.dart
+++ b/packages/hisma/test/state_action_test.dart
@@ -20,13 +20,13 @@ StateMachine<S, E, T> createMachine([dynamic data]) => StateMachine<S, E, T>(
           },
           onEntry: Action(
             description: 'double',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               machine.data = (machine.data as int) * 2;
             },
           ),
           onExit: Action(
             description: 'half',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               machine.data = (machine.data as int) ~/ 2;
             },
           ),
@@ -44,7 +44,7 @@ StateMachine<S, E, T> createMachine([dynamic data]) => StateMachine<S, E, T>(
           to: S.a,
           onAction: Action(
             description: 'decrease',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               machine.data = (machine.data as int) - 2;
             },
           ),
@@ -53,7 +53,7 @@ StateMachine<S, E, T> createMachine([dynamic data]) => StateMachine<S, E, T>(
           to: S.b,
           onAction: Action(
             description: 'increase',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               machine.data = (machine.data as int) + 2;
             },
           ),
@@ -61,7 +61,7 @@ StateMachine<S, E, T> createMachine([dynamic data]) => StateMachine<S, E, T>(
         T.triple: InternalTransition(
           onAction: Action(
             description: 'Triple it.',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               machine.data = (machine.data as int) * 3;
             },
           ),
@@ -69,7 +69,7 @@ StateMachine<S, E, T> createMachine([dynamic data]) => StateMachine<S, E, T>(
         T.trisect: InternalTransition(
           onAction: Action(
             description: 'Trisect it.',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               machine.data = (machine.data as int) ~/ 3;
             },
           ),

--- a/packages/hisma/test/state_change_inside_state_change_test.dart
+++ b/packages/hisma/test/state_change_inside_state_change_test.dart
@@ -66,7 +66,7 @@ StateMachine<S, E, T> createMachine1() => StateMachine<S, E, T>(
 
 Action addAction(String name) => Action(
       description: name,
-      action: (machine, arg) async {
+      action: (machine, arg) {
         print('> $name started.');
         final tmp = (machine.data as int) + 1;
 

--- a/packages/hisma/test/transition_interval_test.dart
+++ b/packages/hisma/test/transition_interval_test.dart
@@ -37,7 +37,7 @@ StateMachine<S, E, T> createSimpleMachine(String name, int value) =>
           minInterval: const Duration(milliseconds: 100),
           onAction: Action(
             description: 'double',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               machine.data = (machine.data as int) * 2;
             },
           ),
@@ -47,13 +47,13 @@ StateMachine<S, E, T> createSimpleMachine(String name, int value) =>
           minInterval: const Duration(milliseconds: 100),
           onAction: Action(
             description: 'double',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               machine.data = (machine.data as int) * 2;
             },
           ),
           onError: OnErrorAction(
             description: 'divide',
-            action: (machine, onErrorData) async {
+            action: (machine, onErrorData) {
               expect(onErrorData.source, OnErrorSource.maxInterval);
               machine.data = (machine.data as int) ~/ 2;
             },
@@ -62,6 +62,7 @@ StateMachine<S, E, T> createSimpleMachine(String name, int value) =>
         T.toEnd: Transition(to: S.end),
       },
     );
+
 void main() {
   group('Transition interval test', () {
     test('Interval test positive - throw', () async {

--- a/packages/hisma/test/transition_on_action_test.dart
+++ b/packages/hisma/test/transition_on_action_test.dart
@@ -28,7 +28,7 @@ StateMachine<S, E, T> createMachine([dynamic data]) => StateMachine<S, E, T>(
           to: S.a,
           onAction: Action(
             description: 'decrease',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               machine.data =
                   (machine.data as int) - (arg != null && arg is int ? arg : 1);
             },
@@ -38,7 +38,7 @@ StateMachine<S, E, T> createMachine([dynamic data]) => StateMachine<S, E, T>(
           to: S.b,
           onAction: Action(
             description: 'increase',
-            action: (machine, arg) async {
+            action: (machine, arg) {
               machine.data =
                   (machine.data as int) + (arg != null && arg is int ? arg : 1);
             },


### PR DESCRIPTION
With this patch, ActionFunction, GuardFunction, and OnErrorActionFunction can be either synchronous or asynchronous form.
_(Hope there are no missing handlers to apply it to.)_